### PR TITLE
Fix/destroyed read

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function write(read, stream, cb) {
         if(!stream.writable) {
           return read(true, function() {
             cleanup()
+            done(true)
           })
         }
 

--- a/index.js
+++ b/index.js
@@ -67,6 +67,12 @@ function write(read, stream, cb) {
           return done(ended)
         }
 
+        if(!stream.writable) {
+          return read(true, function() {
+            cleanup()
+          })
+        }
+
         //I noticed a problem streaming to the terminal:
         //sometimes the end got cut off, creating invalid output.
         //it seems that stdout always emits "drain" when it ends.

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function write(read, stream, cb) {
         if(end === true)
           return stream._isStdio ? done() : stream.end()
 
-        if(ended = ended || end) {
+        if(ended) {
           destroy(stream)
           return done(ended)
         }


### PR DESCRIPTION
`ended` is already being set at the top of the read, so I removed the redundant assignment.

This adds an additional check of `stream.writable` before writing to the stream. This helps prevent some badly behaving streams from throwing an error when the stream has been destroyed, but ended has not been set.

I hit this with some connections using net sockets and this was able to prevent the writes.